### PR TITLE
[Backport] [Resolved : Styling <select> by changing less variables in Luma theme…

### DIFF
--- a/app/design/frontend/Magento/luma/web/css/source/_forms.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_forms.less
@@ -91,11 +91,7 @@
     .select-styling() {
         .lib-css(appearance, none, 1);
         appearance: none;
-        background: @select__background url('../images/select-bg.svg') no-repeat 100% 45%;
         background-size: 30px 60px;
-        border: 1px solid @border-color__base;
-        height: 32px;
-        padding-right: 25px;
         text-indent: .01em;
         text-overflow: '';
 

--- a/app/design/frontend/Magento/luma/web/css/source/_theme.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_theme.less
@@ -153,6 +153,13 @@
 //  Forms
 //  ---------------------------------------------
 
+
+//  Select
+@select__background: @form-element-input__background url('../images/select-bg.svg') no-repeat 100% 45%;
+@select__border: 1px solid @border-color__base;
+@select__height: 32px;
+@select__padding: 4px 25px @indent__xs @indent__s;
+
 //  Form fieldset
 @form-fieldset-legend__font-size: 18px;
 @form-fieldset-legend__font-weight: @font-weight__light;

--- a/lib/web/css/source/lib/variables/_forms.less
+++ b/lib/web/css/source/lib/variables/_forms.less
@@ -121,7 +121,7 @@
 @select__disabled__font-style: @form-element-input__disabled__font-style;
 
 //  Focus state
-@select__focus__background: @form-element-input__focus__background;
+@select__focus__background: false;
 @select__focus__border: @form-element-input__focus__border;
 @select__focus__color: @form-element-input__focus__color;
 @select__focus__font-style: @form-element-input__focus__font-style;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15734
Have "select" elements with the styles you set in _theme.less



### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#https://github.com/magento/magento2/issues/15608 :  Issue title Styling `select` by changing less variables in Luma theme doesn't work as expected 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In Custom/theme/web/css/source/_theme.less set less variables:
@select__background: rgba(255, 255, 255, 0.15);
@select__border: 2px dashed blue;
@select__height: 50px;
@select__padding: 15px 40px 15px 15px;
@select__background-clip: border-box;
2. Compile less

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
