### PR TITLE
[Forwardport] [Resolved : limiter float too generic]

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/GeneralTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/GeneralTest.php
@@ -5,8 +5,11 @@
  */
 namespace Magento\Catalog\Test\Unit\Ui\DataProvider\Product\Form\Modifier;
 
-use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\General;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+use Magento\Eav\Api\Data\AttributeInterface;
+use Magento\Framework\Stdlib\ArrayManager;
 
 /**
  * Class GeneralTest
@@ -15,6 +18,35 @@ use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\General;
  */
 class GeneralTest extends AbstractModifierTest
 {
+    /**
+     * @var AttributeRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $attributeRepositoryMock;
+
+    /**
+     * @var General
+     */
+    private $generalModifier;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->attributeRepositoryMock = $this->getMockBuilder(AttributeRepositoryInterface::class)
+        ->getMockForAbstractClass();
+
+        $arrayManager = $this->objectManager->getObject(ArrayManager::class);
+
+        $this->generalModifier = $this->objectManager->getObject(
+            General::class,
+            [
+                'attributeRepository' => $this->attributeRepositoryMock,
+                'locator' => $this->locatorMock,
+                'arrayManager' => $arrayManager,
+            ]
+        );
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -39,5 +71,60 @@ class GeneralTest extends AbstractModifierTest
                 ]
             ]
         ]));
+    }
+
+    /**
+     * @param array $data
+     * @param int $defaultStatusValue
+     * @param array $expectedResult
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @dataProvider modifyDataDataProvider
+     */
+    public function testModifyDataNewProduct(array $data, int $defaultStatusValue, array $expectedResult)
+    {
+        $attributeMock = $this->getMockBuilder(AttributeInterface::class)
+            ->getMockForAbstractClass();
+        $attributeMock
+            ->method('getDefaultValue')
+            ->willReturn($defaultStatusValue);
+        $this->attributeRepositoryMock
+            ->method('get')
+            ->with(
+                ProductAttributeInterface::ENTITY_TYPE_CODE,
+                ProductAttributeInterface::CODE_STATUS
+            )
+            ->willReturn($attributeMock);
+        $this->assertSame($expectedResult, $this->generalModifier->modifyData($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function modifyDataDataProvider(): array
+    {
+        return [
+            'With default status value' => [
+                'data' => [],
+                'defaultStatusAttributeValue' => 5,
+                'expectedResult' => [
+                    null => [
+                        General::DATA_SOURCE_DEFAULT => [
+                            ProductAttributeInterface::CODE_STATUS => 5,
+                        ],
+                    ],
+                ],
+            ],
+            'Without default status value' => [
+                'data' => [],
+                'defaultStatusAttributeValue' => 0,
+                'expectedResult' => [
+                    null => [
+                        General::DATA_SOURCE_DEFAULT => [
+                            ProductAttributeInterface::CODE_STATUS => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
@@ -7,6 +7,7 @@ namespace Magento\Catalog\Ui\DataProvider\Product\Form\Modifier;
 
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\Eav\Api\AttributeRepositoryInterface;
 use Magento\Ui\Component\Form;
 use Magento\Framework\Stdlib\ArrayManager;
 
@@ -36,20 +37,30 @@ class General extends AbstractModifier
     private $localeCurrency;
 
     /**
+     * @var AttributeRepositoryInterface
+     */
+    private $attributeRepository;
+
+    /**
      * @param LocatorInterface $locator
      * @param ArrayManager $arrayManager
+     * @param AttributeRepositoryInterface|null $attributeRepository
      */
     public function __construct(
         LocatorInterface $locator,
-        ArrayManager $arrayManager
+        ArrayManager $arrayManager,
+        AttributeRepositoryInterface $attributeRepository = null
     ) {
         $this->locator = $locator;
         $this->arrayManager = $arrayManager;
+        $this->attributeRepository = $attributeRepository
+            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(AttributeRepositoryInterface::class);
     }
 
     /**
      * {@inheritdoc}
      * @since 101.0.0
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function modifyData(array $data)
     {
@@ -58,7 +69,12 @@ class General extends AbstractModifier
         $modelId = $this->locator->getProduct()->getId();
 
         if (!isset($data[$modelId][static::DATA_SOURCE_DEFAULT][ProductAttributeInterface::CODE_STATUS])) {
-            $data[$modelId][static::DATA_SOURCE_DEFAULT][ProductAttributeInterface::CODE_STATUS] = '1';
+            $attributeStatus = $this->attributeRepository->get(
+                ProductAttributeInterface::ENTITY_TYPE_CODE,
+                ProductAttributeInterface::CODE_STATUS
+            );
+            $data[$modelId][static::DATA_SOURCE_DEFAULT][ProductAttributeInterface::CODE_STATUS] =
+                $attributeStatus->getDefaultValue() ?: 1;
         }
 
         return $data;

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -188,10 +188,9 @@
         .lib-icon-font-symbol(@icon-list);
     }
 
-    .limiter {
-        float: right;
-
-        .products.wrapper ~ .toolbar & {
+    .toolbar {
+        .products.wrapper ~ & .limiter {
+            float: right;
             display: block;
         }
     }

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -233,9 +233,9 @@
         }
     }
 
-    .limiter {
-        float: right;
-        .products.wrapper ~ .toolbar & {
+    .toolbar {
+        .products.wrapper ~ & .limiter {
+            float: right;
             display: block;
         }
     }

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Section/AdminProductFormSection.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Section/AdminProductFormSection.xml
@@ -10,7 +10,7 @@
     <section name="AdminProductFormSection">
         <element name="productName" type="input" selector=".admin__field[data-index=name] input"/>
         <element name="productSku" type="input" selector=".admin__field[data-index=sku] input"/>
-        <element name="enableProduct" type="checkbox" selector="input[name='product[status]']"/>
+        <element name="productStatus" type="checkbox" selector="input[name='product[status]']"/>
         <element name="productPrice" type="input" selector=".admin__field[data-index=price] input"/>
         <element name="advancedPricingLink" type="button" selector="button[data-index='advanced_pricing_button']"/>
         <element name="categoriesDropdown" type="multiselect" selector="div[data-index='category_ids']"/>

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Section/AdminProductFormSection.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Section/AdminProductFormSection.xml
@@ -10,6 +10,7 @@
     <section name="AdminProductFormSection">
         <element name="productName" type="input" selector=".admin__field[data-index=name] input"/>
         <element name="productSku" type="input" selector=".admin__field[data-index=sku] input"/>
+        <element name="enableProduct" type="checkbox" selector="input[name='product[status]']"/>
         <element name="productPrice" type="input" selector=".admin__field[data-index=price] input"/>
         <element name="advancedPricingLink" type="button" selector="button[data-index='advanced_pricing_button']"/>
         <element name="categoriesDropdown" type="multiselect" selector="div[data-index='category_ids']"/>

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Test/AdminProductStatusAttributeDisabledByDefaultTest.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Test/AdminProductStatusAttributeDisabledByDefaultTest.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="AdminProductStatusAttributeDisabledByDefaultTest">
+        <annotations>
+            <title value="Verify the default option value for product Status attribute is set correctly during product creation"/>
+            <description value="The default option value for product Status attribute is set correctly during product creation"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="MAGETWO-92424"/>
+            <group value="Catalog"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+
+        </before>
+        <after>
+            <amOnPage url="{{AdminProductAttributeGridPage.url}}" stepKey="navigateToProductAttribute"/>
+            <waitForPageLoad stepKey="wait1"/>
+            <click selector="{{AdminProductAttributeGridSection.ResetFilter}}" stepKey="resetFiltersOnGrid1"/>
+            <fillField selector="{{AdminProductAttributeGridSection.GridFilterFrontEndLabel}}" userInput="Enable Product" stepKey="setAttributeLabel1"/>
+            <click selector="{{AdminProductAttributeGridSection.Search}}" stepKey="searchForAttributeFromTheGrid1"/>
+            <click selector="{{AdminProductAttributeGridSection.FirstRow}}" stepKey="clickOnAttributeRow1"/>
+            <waitForPageLoad stepKey="wait2"/>
+            <click selector="{{AdminNewAttributePanel.isDefault('1')}}" stepKey="resetOptionForStatusAttribute"/>
+            <click selector="{{AttributePropertiesSection.Save}}" stepKey="saveAttribute1"/>
+            <waitForPageLoad stepKey="waitForSaveAttribute1"/>
+            <actionGroup ref="ClearCacheActionGroup" stepKey="clearCache1"/>
+
+            <actionGroup ref="logout" stepKey="logoutOfAdmin"/>
+        </after>
+        <amOnPage url="{{AdminProductAttributeGridPage.url}}" stepKey="navigateToProductAttribute"/>
+        <waitForPageLoad stepKey="wait1"/>
+        <click selector="{{AdminProductAttributeGridSection.ResetFilter}}" stepKey="resetFiltersOnGrid"/>
+        <fillField selector="{{AdminProductAttributeGridSection.GridFilterFrontEndLabel}}" userInput="Enable Product" stepKey="setAttributeLabel"/>
+        <click selector="{{AdminProductAttributeGridSection.Search}}" stepKey="searchForAttributeFromTheGrid"/>
+        <click selector="{{AdminProductAttributeGridSection.FirstRow}}" stepKey="clickOnAttributeRow"/>
+        <waitForPageLoad stepKey="wait2"/>
+        <click selector="{{AdminNewAttributePanel.isDefault('2')}}" stepKey="chooseDisabledOptionForStatus"/>
+        <click selector="{{AttributePropertiesSection.Save}}" stepKey="saveAttribute"/>
+        <waitForPageLoad stepKey="waitForAttributeToSave"/>
+        <actionGroup ref="ClearCacheActionGroup" stepKey="clearCache"/>
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex"/>
+        <waitForPageLoad time="30" stepKey="waitForProductGridPageToLoad"/>
+        <click selector="{{AdminProductGridActionSection.addProductToggle}}" stepKey="clickOnAddProductDropdown"/>
+        <click selector="{{AdminProductGridActionSection.addSimpleProduct}}" stepKey="clickOnAddSimpleProduct"/>
+        <waitForPageLoad stepKey="waitForProductEditToLoad"/>
+        <dontSeeCheckboxIsChecked selector="{{AdminProductFormSection.enableProduct}}" stepKey="dontSeeCheckboxEnableProductIsChecked"/>
+
+    </test>
+</tests>

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Test/AdminProductStatusAttributeDisabledByDefaultTest.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/Test/AdminProductStatusAttributeDisabledByDefaultTest.xml
@@ -51,7 +51,7 @@
         <click selector="{{AdminProductGridActionSection.addProductToggle}}" stepKey="clickOnAddProductDropdown"/>
         <click selector="{{AdminProductGridActionSection.addSimpleProduct}}" stepKey="clickOnAddSimpleProduct"/>
         <waitForPageLoad stepKey="waitForProductEditToLoad"/>
-        <dontSeeCheckboxIsChecked selector="{{AdminProductFormSection.enableProduct}}" stepKey="dontSeeCheckboxEnableProductIsChecked"/>
+        <dontSeeCheckboxIsChecked selector="{{AdminProductFormSection.productStatus}}" stepKey="dontSeeCheckboxEnableProductIsChecked"/>
 
     </test>
 </tests>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15878
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
.limiter should have the same parent selectors like .pages to prevent clashes between styles and layouts

### Description
Added selector for floating the element `.limiter` 

### Fixed Issues (if relevant)

<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#https://github.com/magento/magento2/issues/15323: Issue title limiter float too generic

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. inspect toolbar in product list
2. compare styles of `.limiter` and `.pages`

### Actual Result
`.limiter` is too generic and is used as single selector for floating the element

### Expected Result

`.limiter` should have the same parent selectors like .pages to prevent clashes between styles and layouts



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
