### PR TITLE
[Backport] #13899 Solve Canada Zip Code pattern 

### DIFF
--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -211,9 +211,12 @@ class Menu extends \Magento\Backend\Block\Template
     protected function _renderAnchor($menuItem, $level)
     {
         if ($level == 1 && $menuItem->getUrl() == '#') {
-            $output = '<strong class="submenu-group-title" role="presentation">'
-                . '<span>' . $this->_getAnchorLabel($menuItem) . '</span>'
-                . '</strong>';
+            $output = '';
+            if ($menuItem->hasChildren()) {
+                $output = '<strong class="submenu-group-title" role="presentation">'
+                    . '<span>' . $this->_getAnchorLabel($menuItem) . '</span>'
+                    . '</strong>';
+            }
         } else {
             $output = '<a href="' . $menuItem->getUrl() . '" ' . $this->_renderItemAnchorTitle(
                 $menuItem

--- a/app/code/Magento/Braintree/i18n/en_US.csv
+++ b/app/code/Magento/Braintree/i18n/en_US.csv
@@ -166,3 +166,4 @@ Debug,Debug
 "apple_pay_card","Apple pay card"
 "android_pay_card","Android pay card"
 "Accept credit/debit cards and PayPal in your Magento store.<br/>No setup or monthly fees and your customers never leave your store to complete the purchase.","Accept credit/debit cards and PayPal in your Magento store.<br/>No setup or monthly fees and your customers never leave your store to complete the purchase."
+"Save for later use.","Save for later use."

--- a/app/code/Magento/Braintree/view/adminhtml/templates/form/cc.phtml
+++ b/app/code/Magento/Braintree/view/adminhtml/templates/form/cc.phtml
@@ -84,7 +84,7 @@ $ccType = $block->getInfoData('cc_type');
                    name="payment[is_active_payment_token_enabler]"
                    class="admin__control-checkbox"/>
             <label class="label" for="<?php /* @noEscape */ echo $code; ?>_vault">
-                <span><?php echo $block->escapeHtml('Save for later use.'); ?></span>
+                <span><?php echo $block->escapeHtml(__('Save for later use.')); ?></span>
             </label>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Catalog/Setup/InstallSchema.php
+++ b/app/code/Magento/Catalog/Setup/InstallSchema.php
@@ -674,7 +674,7 @@ class InstallSchema implements InstallSchemaInterface
                 \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
                 null,
                 ['unsigned' => true, 'nullable' => false, 'default' => '0'],
-                'Attriute Set ID'
+                'Attribute Set ID'
             )
             ->addColumn(
                 'parent_id',

--- a/app/code/Magento/Catalog/view/base/web/js/price-utils.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-utils.js
@@ -70,7 +70,7 @@ define([
         am = Number(Math.round(Math.abs(amount - i) + 'e+' + precision) + ('e-' + precision));
         r = (j ? i.substr(0, j) + groupSymbol : '') +
             i.substr(j).replace(re, '$1' + groupSymbol) +
-            (precision ? decimalSymbol + am.toFixed(2).replace(/-/, 0).slice(2) : '');
+            (precision ? decimalSymbol + am.toFixed(precision).replace(/-/, 0).slice(2) : '');
 
         return pattern.replace('%s', r).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
     }

--- a/app/code/Magento/Checkout/etc/webapi.xml
+++ b/app/code/Magento/Checkout/etc/webapi.xml
@@ -104,7 +104,7 @@
             <resource ref="anonymous" />
         </resources>
     </route>
-    <!-- Managing My shipping information -->
+    <!-- Managing My payment information -->
     <route url="/V1/carts/mine/set-payment-information" method="POST">
         <service class="Magento\Checkout\Api\PaymentInformationManagementInterface" method="savePaymentInformation"/>
         <resources>

--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -81,6 +81,7 @@
     <zip countryCode="CA">
         <codes>
             <code id="pattern_1" active="true" example="A1B 2C3">^[a-zA-z]{1}[0-9]{1}[a-zA-z]{1}\s[0-9]{1}[a-zA-z]{1}[0-9]{1}$</code>
+            <code id="pattern_2" active="true" example="A1B2C3">^[a-zA-z]{1}[0-9]{1}[a-zA-z]{1}[0-9]{1}[a-zA-z]{1}[0-9]{1}$</code>
         </codes>
     </zip>
     <zip countryCode="IC">

--- a/app/code/Magento/Paypal/i18n/en_US.csv
+++ b/app/code/Magento/Paypal/i18n/en_US.csv
@@ -680,3 +680,4 @@ User,User
 "payflowpro","Payflow Pro"
 "Payments Pro","Payments Pro"
 "Website Payments Pro","Website Payments Pro"
+"Save for later use.","Save for later use."

--- a/app/code/Magento/Paypal/view/adminhtml/templates/transparent/form.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/transparent/form.phtml
@@ -135,7 +135,7 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                    name="payment[is_active_payment_token_enabler]"
                    class="admin__control-checkbox"/>
             <label class="label" for="<?php /* @noEscape */ echo $code; ?>_vault">
-                <span><?php echo $block->escapeHtml('Save for later use.'); ?></span>
+                <span><?php echo $block->escapeHtml(__('Save for later use.')); ?></span>
             </label>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Review/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Review/etc/adminhtml/menu.xml
@@ -9,7 +9,7 @@
     <menu>
         <add id="Magento_Review::catalog_reviews_ratings_ratings" title="Rating" translate="title" module="Magento_Review" sortOrder="60" parent="Magento_Backend::stores_attributes" action="review/rating/" resource="Magento_Review::ratings"/>
         <add id="Magento_Review::catalog_reviews_ratings_reviews_all" title="Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="10" action="review/product/index" resource="Magento_Review::reviews_all"/>
-    <add id="Magento_Review::report_review" title="Reviews" translate="title" module="Magento_Reports" sortOrder="20" parent="Magento_Reports::report" resource="Magento_Reports::review"/>
+        <add id="Magento_Review::report_review" title="Reviews" translate="title" module="Magento_Reports" sortOrder="20" parent="Magento_Reports::report" resource="Magento_Reports::review"/>
         <add id="Magento_Review::report_review_customer" title="By Customers" translate="title" sortOrder="10" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/customer" resource="Magento_Reports::review_customer"/>
         <add id="Magento_Review::report_review_product" title="By Products" translate="title" sortOrder="20" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/product" resource="Magento_Reports::review_product"/>
     </menu>

--- a/app/code/Magento/UrlRewrite/Block/Catalog/Product/Edit.php
+++ b/app/code/Magento/UrlRewrite/Block/Catalog/Product/Edit.php
@@ -55,7 +55,7 @@ class Edit extends \Magento\UrlRewrite\Block\Edit
         }
 
         if ($this->_getProduct()->getId()) {
-            $this->_addProductLinkBlock($this->_getProduct());
+            $this->_addProductLinkBlock();
         }
 
         if ($this->_getCategory()->getId()) {

--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -39,7 +39,7 @@ class Generator extends AbstractSchemaGenerator
     const UNAUTHORIZED_DESCRIPTION = '401 Unauthorized';
 
     /** Array signifier */
-    const ARRAY_SIGNIFIER = '[]';
+    const ARRAY_SIGNIFIER = '[0]';
 
     /**
      * Swagger factory instance.

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -42,22 +42,33 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate('12345', 'INVALID-CODE');
     }
 
-    public function testInvalidCanadaZipCode() {
-        $resultOnlyDigits               = $this->validator->validate('12345', 'CA');
-        $resultMoreCharactersThanNeeded = $this->validator->validate('A1B2C3D', 'CA');
-        $resultLessCharactersThanNeeded = $this->validator->validate('A1B2C', 'CA');
-        $resultMoreThanOneSpace         = $this->validator->validate('A1B  2C3', 'CA');
-        $this->assertFalse($resultOnlyDigits);
-        $this->assertFalse($resultMoreCharactersThanNeeded);
-        $this->assertFalse($resultLessCharactersThanNeeded);
-        $this->assertFalse($resultMoreThanOneSpace);
+    /**
+     * @dataProvider getCanadaInvalidPostCodes
+     */
+    public function testInvalidCanadaZipCode($countryId, $invalidPostCode) {
+        $this->assertFalse($this->validator->validate($invalidPostCode, $countryId));
     }
 
+    /**
+     *
+     */
     public function testValidCanadaZipCode() {
         $resultPattern1 = $this->validator->validate('A1B2C3', 'CA');
         $resultPattern2 = $this->validator->validate('A1B 2C3', 'CA');
         $this->assertTrue($resultPattern1);
         $this->assertTrue($resultPattern2);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCanadaInvalidPostCodes() {
+        return [
+            ['countryId' => 'CA', 'postcode' => '12345'],
+            ['countryId' => 'CA', 'postcode' => 'A1B2C3D'],
+            ['countryId' => 'CA', 'postcode' => 'A1B2C'],
+            ['countryId' => 'CA', 'postcode' => 'A1B  2C3'],
+        ];
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -42,6 +42,24 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate('12345', 'INVALID-CODE');
     }
 
+    public function testInvalidCanadaZipCode() {
+        $resultOnlyDigits               = $this->validator->validate('12345', 'CA');
+        $resultMoreCharactersThanNeeded = $this->validator->validate('A1B2C3D', 'CA');
+        $resultLessCharactersThanNeeded = $this->validator->validate('A1B2C', 'CA');
+        $resultMoreThanOneSpace         = $this->validator->validate('A1B  2C3', 'CA');
+        $this->assertFalse($resultOnlyDigits);
+        $this->assertFalse($resultMoreCharactersThanNeeded);
+        $this->assertFalse($resultLessCharactersThanNeeded);
+        $this->assertFalse($resultMoreThanOneSpace);
+    }
+
+    public function testValidCanadaZipCode() {
+        $resultPattern1 = $this->validator->validate('A1B2C3', 'CA');
+        $resultPattern2 = $this->validator->validate('A1B 2C3', 'CA');
+        $this->assertTrue($resultPattern1);
+        $this->assertTrue($resultPattern2);
+    }
+
     /**
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -50,13 +50,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
+     * @dataProvider getCanadaValidPostCodes
      */
-    public function testValidCanadaZipCode() {
-        $resultPattern1 = $this->validator->validate('A1B2C3', 'CA');
-        $resultPattern2 = $this->validator->validate('A1B 2C3', 'CA');
-        $this->assertTrue($resultPattern1);
-        $this->assertTrue($resultPattern2);
+    public function testValidCanadaZipCode($countryId, $validPostCode) {
+        $this->assertTrue($this->validator->validate($validPostCode, $countryId));
     }
 
     /**
@@ -68,6 +65,18 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ['countryId' => 'CA', 'postcode' => 'A1B2C3D'],
             ['countryId' => 'CA', 'postcode' => 'A1B2C'],
             ['countryId' => 'CA', 'postcode' => 'A1B  2C3'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getCanadaValidPostCodes() {
+        return [
+            ['countryId' => 'CA', 'postcode' => 'A1B2C3'],
+            ['countryId' => 'CA', 'postcode' => 'A1B 2C3'],
+            ['countryId' => 'CA', 'postcode' => 'Z9Y 8X7'],
+            ['countryId' => 'CA', 'postcode' => 'Z9Y8X7'],
         ];
     }
 

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -45,21 +45,24 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getCanadaInvalidPostCodes
      */
-    public function testInvalidCanadaZipCode($countryId, $invalidPostCode) {
+    public function testInvalidCanadaZipCode($countryId, $invalidPostCode)
+    {
         $this->assertFalse($this->validator->validate($invalidPostCode, $countryId));
     }
 
     /**
      * @dataProvider getCanadaValidPostCodes
      */
-    public function testValidCanadaZipCode($countryId, $validPostCode) {
+    public function testValidCanadaZipCode($countryId, $validPostCode)
+    {
         $this->assertTrue($this->validator->validate($validPostCode, $countryId));
     }
 
     /**
      * @return array
      */
-    public function getCanadaInvalidPostCodes() {
+    public function getCanadaInvalidPostCodes()
+    {
         return [
             ['countryId' => 'CA', 'postcode' => '12345'],
             ['countryId' => 'CA', 'postcode' => 'A1B2C3D'],
@@ -71,7 +74,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function getCanadaValidPostCodes() {
+    public function getCanadaValidPostCodes()
+    {
         return [
             ['countryId' => 'CA', 'postcode' => 'A1B2C3'],
             ['countryId' => 'CA', 'postcode' => 'A1B 2C3'],

--- a/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
+++ b/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
@@ -188,8 +188,8 @@ class SearchResultProcessor extends AbstractDataObject implements SearchResultPr
     }
 
     /**
-     * @param string $labelField
-     * @param string $labelField
+     * @param string|null $valueField
+     * @param string|null $labelField
      * @param array $additional
      * @return array
      */

--- a/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
+++ b/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
@@ -188,8 +188,8 @@ class SearchResultProcessor extends AbstractDataObject implements SearchResultPr
     }
 
     /**
-     * @param null $valueField
-     * @param null $labelField
+     * @param string $labelField
+     * @param string $labelField
      * @param array $additional
      * @return array
      */

--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -72,6 +72,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'mk_MK', /*Macedonian (Macedonia)*/
         'mn_Cyrl_MN', /*Mongolian (Mongolia)*/
         'ms_Latn_MY', /*Malaysian (Malaysia)*/
+        'ms_MY', /*Malaysian (Malaysia)*/
         'nl_BE', /*Dutch (Belgium)*/
         'nl_NL', /*Dutch (Netherlands)*/
         'nb_NO', /*Norwegian BokmГ_l (Norway)*/

--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -98,6 +98,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'lo_LA', /*Laotian*/
         'es_VE', /*Spanish (Venezuela)*/
         'en_IE', /*English (Ireland)*/
+        'es_BO', /*Spanish (Bolivia)*/
     ];
 
     /**

--- a/lib/web/css/docs/source/docs.less
+++ b/lib/web/css/docs/source/docs.less
@@ -21,7 +21,6 @@
 @import '_icons.less';
 @import '_loaders.less';
 @import '_messages.less';
-//@import 'navigation.less';
 @import '_layout.less';
 @import '_pages.less';
 @import '_popups.less';


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13930
Add new pattern to validate Canada Zip Codes

### Description
Change pattern validation for Canada Zip Codes

### Fixed Issues (if relevant)
1. magento/magento2#13899: Postal code (zip code) for Canada should allow postal codes without space

### Manual testing scenarios
1. Add Product to Cart
2. Go to shopping cart
3. Select Canda Country
4. Put ZipCode: A1B2C3

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
